### PR TITLE
Add wheel navigation for carousel

### DIFF
--- a/apps/carrousel-generator.js
+++ b/apps/carrousel-generator.js
@@ -100,6 +100,7 @@ function carrouselApp() {
 
         setupEventHandlers() {
             this.setupKeyboardShortcuts();
+            this.setupWheelNavigation();
             this.setupPasteHandler();
             this.setupInteractJS();
         },
@@ -447,6 +448,26 @@ function carrouselApp() {
                         break;
                 }
             });
+        },
+
+        setupWheelNavigation() {
+            document.addEventListener('wheel', (e) => {
+                if (e.target.contentEditable === 'true' ||
+                    e.target.tagName === 'INPUT' ||
+                    e.target.tagName === 'TEXTAREA') return;
+
+                const now = Date.now();
+                if (now - this.lastKeyTime < CONFIG.DEBOUNCE_TIME.KEYBOARD) return;
+                this.lastKeyTime = now;
+
+                if (e.deltaY > 0 && this.activeSlide < this.slides.length - 1) {
+                    e.preventDefault();
+                    this.setActiveSlide(this.activeSlide + 1);
+                } else if (e.deltaY < 0 && this.activeSlide > 0) {
+                    e.preventDefault();
+                    this.setActiveSlide(this.activeSlide - 1);
+                }
+            }, { passive: false });
         },
 
         setupInteractJS() {

--- a/apps/carrousel-generator.test-keyboard.js
+++ b/apps/carrousel-generator.test-keyboard.js
@@ -39,6 +39,39 @@ test.describe('Carousel Generator - Keyboard Shortcuts', () => {
     expect(errors).toEqual([]);
   });
 
+  test('mouse wheel navigates slides', async ({ page }) => {
+    const errors = [];
+    page.on('console', msg => {
+      if (msg.type() === 'error') {
+        errors.push(msg.text());
+      }
+    });
+
+    await page.goto(`file://${path.resolve(__dirname, 'carrousel-generator.html')}`);
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(1000);
+
+    await page.click('button[title="Add Slide"]');
+    await page.waitForTimeout(500);
+
+    let slideIndicator = await page.textContent('.slide-indicator');
+    expect(slideIndicator).toBe('2/2');
+
+    await page.mouse.wheel(0, -500);
+    await page.waitForTimeout(300);
+
+    slideIndicator = await page.textContent('.slide-indicator');
+    expect(slideIndicator).toBe('1/2');
+
+    await page.mouse.wheel(0, 500);
+    await page.waitForTimeout(300);
+
+    slideIndicator = await page.textContent('.slide-indicator');
+    expect(slideIndicator).toBe('2/2');
+
+    expect(errors).toEqual([]);
+  });
+
   test('keyboard shortcuts work for slide management', async ({ page }) => {
     const errors = [];
     page.on('console', msg => {


### PR DESCRIPTION
## Summary
- allow navigating carousel slides with the mouse wheel
- test mouse wheel navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688032628d748332b81a471b4f794b0c